### PR TITLE
出品一覧ビュー修正

### DIFF
--- a/app/assets/stylesheets/users/_listing-items.scss
+++ b/app/assets/stylesheets/users/_listing-items.scss
@@ -4,7 +4,12 @@
   display: flex;
   justify-content: space-between;
   &:hover {
-    opacity: 0.5;
+    background-color: rgba(225, 225, 225, 0.5);
+    opacity: 1;
+    .listing-list__items{
+      background-color:  rgba(200, 200, 200, 0);
+      opacity: 1;
+    }
   }
   &__items {
     color: black;


### PR DESCRIPTION
opacity:1;
デフォルトではホバー時に薄く表示されてしまうことを修正
background-color:;
ホバー時の色を設定
全体に適用させるため二箇所に設定
isting-list__itemsのbackground-color:;は色が重なり濃くなってしまうため透明度０に設定